### PR TITLE
Update main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,7 @@
       - php7.0-snmp
       - php7.0-zip
       - php7.0-bcmath
+      - php7.0-soap
   when: ansible_distribution_version == "16.04"
 
 - set_fact: 


### PR DESCRIPTION
php7.0-soap hinzugefügt, da sonst die Installation/das Update auf i-doit 1.11 crasht